### PR TITLE
Updated Instruments.jl to work with Julia v1.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,106 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.10"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "195a3ffcb8b0762684b6821de18f83a16455c6ea"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "2.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,9 @@
+name = "Instruments"
+uuid = "2c6aeda0-45f5-11e9-10ba-f7b3d6416888"
+authors = ["Alex Porter <aporter@blueorigin.com>"]
+version = "0.1.0"
+
+[deps]
+BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Instruments
 
+Forked for updating by Alex Porter
+
 Instrument control with Julia.  
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Instruments
 
-Forked for updating by Alex Porter
+Updated to work with V1.0
 
 Instrument control with Julia.  
 
@@ -13,9 +13,10 @@ Available [online](http://instrumentsjl.readthedocs.org/).
 ```
 using Instruments
 
-instruments = find_resources() # returns a list of VISA strings for all found instruments
+rm = ResourceManager()
+instruments = find_resources(rm) # returns a list of VISA strings for all found instruments
 uwSource = Instrument()
-connect!(uwSource, "GPIB0::28::INSTR")
+connect!(rm, uwSource, "GPIB0::28::INSTR")
 query(uwSource, "*IDN?") # prints "Rohde&Schwarz,SMIQ...."
 disconnect!(uwSource)
 ```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.4
-BinDeps

--- a/deps/deps.jl
+++ b/deps/deps.jl
@@ -1,0 +1,23 @@
+# This is an auto-generated file; do not edit and do not check-in to version control
+
+# Pre-hooks
+
+if VERSION >= v"0.7.0-DEV.3382"
+    using Libdl
+end
+# Macro to load a library
+macro checked_lib(libname, path)
+    if Libdl.dlopen_e(path) == C_NULL
+        error("Unable to load \n\n$libname ($path)\n\nPlease ",
+              "re-run Pkg.build(package), and restart Julia.")
+    end
+    quote
+        const $(esc(libname)) = $path
+    end
+end
+
+# Load dependencies
+@checked_lib libvisa "C:\\Windows\\system32\\visa64.DLL"
+
+# Load-hooks
+

--- a/src/Instruments.jl
+++ b/src/Instruments.jl
@@ -24,6 +24,6 @@ include("scpi.jl")
 ResourceManager() = viOpenDefaultRM()
 
 # Helper functions to find instruments
-find_resources(expr::AbstractString="?*::INSTR") = Instruments.viFindRsrc(Instruments.rm, expr)
+find_resources(rm, expr::AbstractString="?*::INSTR") = Instruments.viFindRsrc(rm, expr)
 
 end # module

--- a/src/Instruments.jl
+++ b/src/Instruments.jl
@@ -1,6 +1,7 @@
 module Instruments
 
 export Instrument, GenericInstrument, connect!, disconnect!, write, read, query
+export viOpenDefaultRM, viClose
 export find_resources
 export @scpifloat
 export @scpibool
@@ -17,7 +18,7 @@ end
 include("visa/VISA.jl")
 
 #Setup global resource manager
-rm = viOpenDefaultRM()
+#rm = viOpenDefaultRM()
 
 include("instrument.jl")
 

--- a/src/Instruments.jl
+++ b/src/Instruments.jl
@@ -1,7 +1,7 @@
 module Instruments
 
 export Instrument, GenericInstrument, connect!, disconnect!, write, read, query
-export viOpenDefaultRM, viClose
+export ResourceManager
 export find_resources
 export @scpifloat
 export @scpibool
@@ -17,13 +17,11 @@ end
 
 include("visa/VISA.jl")
 
-#Setup global resource manager
-#rm = viOpenDefaultRM()
-
 include("instrument.jl")
 
 include("scpi.jl")
 
+ResourceManager() = viOpenDefaultRM()
 
 # Helper functions to find instruments
 find_resources(expr::AbstractString="?*::INSTR") = Instruments.viFindRsrc(Instruments.rm, expr)

--- a/src/instrument.jl
+++ b/src/instrument.jl
@@ -14,7 +14,7 @@ function connect!(rm, instr::Instrument, address::AbstractString)
 	end
 end
 
-function disconnect!(rm, instr::Instrument)
+function disconnect!(instr::Instrument)
 	if instr.connected
 		viClose(instr.handle)
 		instr.connected = false

--- a/src/visa/codes.jl
+++ b/src/visa/codes.jl
@@ -109,7 +109,7 @@ const VI_ERROR_NPERMISSION       = VI_ERROR+0x3FFF00A8 # BFFF00A8, -1073807192
 # Dictionary mapping codes to more verbose information #
 # See Appendix A of the NI-VISA Programmers Reference
 #Dictionary maps integer codes to tuples of (Code, Meaning)
-codes = Dict{Int,Tuple{ASCIIString,ASCIIString}}(
+codes = Dict{Int,Tuple{String,String}}(
     VI_SUCCESS => ("VI_SUCCESS", "Operation completed successfully."),
     VI_SUCCESS_EVENT_EN => ("VI_SUCCESS_EVENT_EN", "Specified event is already enabled for at least one of the specified mechanisms."),
     VI_SUCCESS_EVENT_DIS => ("VI_SUCCESS_EVENT_DIS", "Specified event is already disabled for at least one of the specified mechanisms."),

--- a/src/visa/constants.jl
+++ b/src/visa/constants.jl
@@ -1,5 +1,5 @@
 #- Other VISA Definitions --------------------------------------------------*/
-
+const WORD_SIZE = 64
 const VI_NULL = 0
 
 const VI_TRUE = 1
@@ -181,9 +181,9 @@ const VI_ATTR_PXI_RECV_INTR_DATA          =  0x3FFF4241
 #- Attributes (platform dependent size) ------------------------------------*/
 
 if WORD_SIZE == 64
-  typealias ViAttrState ViUInt64
+  ViAttrState = ViUInt64
 else
-  typealias ViAttrState ViUInt32
+  ViAttrState = ViUInt32
 end
 
 if WORD_SIZE == 64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,15 +3,10 @@ using Test
 
 # write your own tests here
 @test 1 == 1
-rm = viOpenDefaultRM()
+rm = ResourceManager()
 insts = Vector{String}()
 try
     push!(insts, Instruments.viFindRsrc(rm, "?*::INSTR")...)
 catch LoadError
     viClose(rm)
 end
-
-test_inst = GenericInstrument()
-connect!(rm, test_inst, insts[1])
-@show query(test_inst, "*IDN?")
-disconnect!(rm, test_inst)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,17 @@
 using Instruments
-using Base.Test
+using Test
 
 # write your own tests here
 @test 1 == 1
+rm = viOpenDefaultRM()
+insts = Vector{String}()
+try
+    push!(insts, Instruments.viFindRsrc(rm, "?*::INSTR")...)
+catch LoadError
+    viClose(rm)
+end
+
+test_inst = GenericInstrument()
+connect!(rm, test_inst, insts[1])
+@show query(test_inst, "*IDN?")
+disconnect!(rm, test_inst)


### PR DESCRIPTION
I updated the source code, ccalls, and the wrapper data types to be compatible with Julia v1.0. I have done some small scale bench testing with some instruments I have via USB and everything seems to work fine. The source code could use some polishing. And moving to a Julia native API down the road may be nice, similar to pyvisa-py that is a Python native PyVisa.